### PR TITLE
Fix render path bug, add night-serif theme

### DIFF
--- a/marknow/lib/renderer.py
+++ b/marknow/lib/renderer.py
@@ -42,7 +42,7 @@ def serve_path(file_path):
     '''Handle routes that indicate directories (not renderable files)
     '''
 
-    path = Path(f"{app.config['DIRECTORY']}/{file_path}")
+    path = Path(f"{app.config['DIRECTORY']}/{file_path}").absolute()
     if not path.exists():
         return render_template('404.html.j2'), 404
     if path.is_dir():
@@ -56,7 +56,6 @@ def render_path(path, refresh_seconds=None):
     '''Handle routes that indicate Markdown files in need of rendering
     '''
 
-    print(path)
     if not path.exists() or not path.is_file():
         return render_template('404.html.j2'), 404
     with open(path, 'r') as fh:
@@ -71,21 +70,20 @@ def serve_path_as_file(file_path, refresh_seconds=None):
     '''
 
     # Reject the request if the path being requested is above the project's path
-    path = Path(f"{app.config['DIRECTORY']}/{file_path}").resolve()
-    highest_path = Path(f"{app.config['DIRECTORY']}").resolve()
+    highest_path = Path(f"{app.config['DIRECTORY']}").absolute()
     try:
-        path.relative_to(highest_path)
+        file_path.relative_to(highest_path)
     except ValueError:
         return render_template('400.html.j2'), 400
 
     # 404 if the file doesn't exist
-    if not path.exists() or not path.is_file():
+    if not file_path.exists() or not file_path.is_file():
         return render_template('404.html.j2'), 404
 
     # Render Markdown files
     if file_path.parts[-1][-3:] == '.md':
         return render_path(file_path, refresh_seconds)
     
-    directory = Path('/'.join(path.parts[:-1])).resolve()
-    file = path.parts[-1]
+    directory = Path('/'.join(file_path.parts[:-1])).resolve()
+    file = file_path.parts[-1]
     return send_from_directory(directory, file)

--- a/marknow/static/styles/night-serif.css
+++ b/marknow/static/styles/night-serif.css
@@ -1,0 +1,80 @@
+body {
+  font-family: "C059", serif;
+  background-color: #222;
+  color: #ddd;
+  line-height: 150%;
+}
+
+div.content {
+  max-width: 500px;
+  margin: auto;
+  padding: 10px;
+}
+
+h1 {
+  color: #70cfff;
+}
+
+h2, h3 {
+  color: #9cdeff;
+}
+
+table, th, tr, td {
+  border: 1px #aaa solid;
+  border-spacing: 0;
+  margin: auto;
+  text-align: center;
+  padding: 0px;
+}
+
+td, th {
+  padding: 4px;
+  border: none;
+  border-left: 1px#888 solid;
+  border-top: 1px#888 solid;
+}
+
+.centered {
+  text-align: center;
+}
+
+img {
+  max-width: 700px;
+  margin: auto;
+  border: 1px solid #000;
+  border-radius: 8px;
+}
+
+blockquote {
+  border-left: 4px solid #70cfff;
+  padding-left: 6px;
+}
+
+a:link {
+  color: #70cfff;
+}
+
+a:visited {
+  color: #ea70ff;
+}
+
+a:hover {
+  color: #a3e0ff;
+}
+
+a:active {
+  color: #a3e0ff;
+}
+
+pre {
+  margin-left: 40px;
+  margin-right: 40px;
+  padding-top: 5px;
+  padding-bottom: 10px;
+  padding-left: 20px;
+  padding-right: 20px;
+  background-color: #000;
+  color: #ccc;
+  font-size: larger;
+  font-family: 'Droid Sans Mono'
+}


### PR DESCRIPTION
If we use `Path.absolute()` we only have to resolve a file path once. That gets passed into the actual renderer where we no longer have to mangle the path to determine if the file is servable, which is where this bug came about.